### PR TITLE
feat(server): add unified bulk catalog export API for enabled resources

### DIFF
--- a/docs/catalog/remote-catalog-api.md
+++ b/docs/catalog/remote-catalog-api.md
@@ -300,5 +300,90 @@ Configure the extension (settings.json):
 For questions or enhancements, open an issue in the repository referencing this document (`remote-catalog-api.md`). Provide example URLs, manifest samples, and logs (with sensitive data removed).
 
 ---
+## 16. (Database Mode) Bulk Catalog Export API
+
+Provides a single fetch of all enabled catalogs and their enabled resources with a lean schema (IDs and enabled flags removed; resource type implied by grouping).
+
+Endpoint:
+```
+GET /admin/catalog-export
+```
+
+Minimal Response Structure:
+```jsonc
+{
+	"generated_at": "2025-09-19T21:30:00.000Z",
+	"catalogs": [
+		{
+			"name": "engineering",
+			"display_name": "Engineering Catalog",
+			"description": "Primary engineering assistant assets",
+			"source_type": "local",
+			"source_path": null,
+			"source_url": null,
+			"created_at": "2025-09-19T20:00:00.000Z",
+			"updated_at": "2025-09-19T21:00:00.000Z",
+			"resources": {
+				"instructions": [
+					{
+						"filename": "onboarding.instructions.md",
+						"title": "Onboarding Guide",
+						"description": "Team onboarding sequence",
+						"category": "people-success",
+						"tags": "hr,getting-started",
+						"content_type": "text/markdown",
+						"resource_type": "content",
+						"content": "# Onboarding...",          // Present iff content resource and <=50KB
+						"truncated": true,                      // Indicates large content omitted
+						"size": 98765,                          // Character size when truncated or for reference
+						"created_at": "2025-09-18T18:00:00.000Z",
+						"updated_at": "2025-09-19T18:00:00.000Z"
+					}
+				],
+				"chatmodes": [],
+				"prompts": [],
+				"tasks": [],
+				"mcp": []
+			}
+		}
+	],
+	"counts": { "catalogs": 1, "resources": 42 }
+}
+```
+
+Resource Summary Fields (per category array):
+| Field | Notes |
+|-------|-------|
+| filename | Resource file name as stored |
+| title, description | Optional metadata if provided |
+| category, tags | Optional domain taxonomy / search tags |
+| content_type | MIME/derived type (e.g. `text/markdown`) |
+| resource_type | `content` or `url` |
+| content_url | Present only for `url` resources |
+| metadata | Parsed JSON if original metadata existed |
+| content | Inlined only when `resource_type=content` and size <= 50KB |
+| truncated | Boolean flag if original content exceeded inline limit |
+| size | Character length for content resources (always when truncated, optional otherwise) |
+| created_at / updated_at | Original timestamps |
+
+Behavior & Constraints:
+* Only enabled catalogs/resources are returned; disabled items filtered server side.
+* No `id`, `enabled`, or per-entry `type` properties (type implicit by array key).
+* >50KB content omitted; `truncated` + `size` signal presence and original length.
+* Hard guard at 10,000 resources → `413 export_too_large` response.
+* `Cache-Control: no-store` to encourage fresh pulls; clients may cache if desired.
+
+Intended Uses:
+* One-step synchronization (search index, offline snapshot, diffing environment contents).
+* Bootstrap for tooling that needs full metadata before selective caching.
+
+Planned / Potential Enhancements (non-breaking):
+* Pagination or streaming (`?cursor=`)
+* `?inlineContent=false` toggle
+* Per-resource hash digests for delta sync
+* ETag/If-None-Match conditional fetch
+* Field projection (`?fields=filename,title`)
+
+---
 *Last updated: 2025-09-15*
 

--- a/server/src/http/routes/admin.ts
+++ b/server/src/http/routes/admin.ts
@@ -22,29 +22,39 @@ interface ResourceContentResponse {
 // Validation schemas
 const resourceTypeSchema = z.enum(['chatmodes', 'instructions', 'prompts', 'tasks', 'mcp']);
 
+// Accept both 'type' (preferred) and legacy 'category' field pointing to resource type (instructions, prompts, etc.)
 const createResourceSchema = z.object({
   catalogId: z.number().int().positive(),
-  type: resourceTypeSchema,
+  type: resourceTypeSchema.optional(),
+  // legacy alias (tests used 'category' originally to mean resource type)
+  category: resourceTypeSchema.optional(),
   filename: z.string().min(1).max(255),
   title: z.string().optional(),
   description: z.string().optional(),
-  category: z.string().optional(), // Domain/technology category
-  tags: z.string().optional(), // Comma-separated tags
+  // domainCategory: domain classification separate from resource type (retain legacy naming confusion)
+  domainCategory: z.string().optional(),
+  tags: z.string().optional(),
   content: z.string().optional(),
   contentUrl: z.string().url().optional(),
   resourceType: z.enum(['content', 'url']).default('content'),
   metadata: z.record(z.any()).optional(),
 }).refine((data) => {
-  if (data.resourceType === 'content' && !data.content) {
-    return false;
-  }
-  if (data.resourceType === 'url' && !data.contentUrl) {
-    return false;
-  }
-  return true;
-}, {
-  message: "Content is required for content resources, contentUrl is required for URL resources"
-});
+  // Require at least one of type/category alias (strict comparison per lint)
+  return (data.type ?? data.category) !== null && (data.type ?? data.category) !== undefined;
+}, { message: 'type (or legacy category) is required' })
+  .refine((data) => {
+    if (data.resourceType === 'content' && !data.content) { return false; }
+    if (data.resourceType === 'url' && !data.contentUrl) { return false; }
+    return true;
+  }, { message: 'Content is required for content resources, contentUrl is required for URL resources' })
+  .transform((data) => {
+    const normalizedType = data.type ?? data.category; // guaranteed by refine above
+    return {
+      ...data,
+      type: normalizedType as typeof normalizedType & NonNullable<typeof normalizedType>,
+      category: data.domainCategory ?? undefined
+    };
+  });
 
 const updateResourceSchema = z.object({
   title: z.string().optional(),
@@ -186,16 +196,21 @@ export function createAdminRoutes(dbService: DatabaseService, indexCache?: LruCa
   // POST /admin/resources - Create new resource
   router.post('/resources', async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const data = createResourceSchema.parse(req.body);
+  const data = createResourceSchema.parse(req.body);
       
       if (!catalogProvider.create) {
         return res.status(501).json({ error: 'Resource creation not supported in current mode' });
       }
 
+      if (!data.type) {
+        // Should be unreachable due to refine, but runtime guard for safety
+        return res.status(400).json({ error: 'Invalid resource type (missing after validation)' });
+      }
+      const resourceTypeId = data.type;
       if (data.resourceType === 'content') {
         await catalogProvider.create(
           data.catalogId,
-          data.type,
+          resourceTypeId,
           data.filename,
           data.content ?? '',
           data.metadata,
@@ -209,7 +224,7 @@ export function createAdminRoutes(dbService: DatabaseService, indexCache?: LruCa
       } else {
         await catalogProvider.create(
           data.catalogId,
-          data.type,
+          resourceTypeId,
           data.filename,
           undefined as never,
           data.metadata,
@@ -227,7 +242,7 @@ export function createAdminRoutes(dbService: DatabaseService, indexCache?: LruCa
         .selectFrom('resources')
         .selectAll()
         .where('catalog_id', '=', data.catalogId)
-        .where('type', '=', data.type)
+        .where('type', '=', resourceTypeId)
         .where('filename', '=', data.filename)
         .executeTakeFirstOrThrow();
 
@@ -239,7 +254,7 @@ export function createAdminRoutes(dbService: DatabaseService, indexCache?: LruCa
       }, 'Resource created');
       
       // Invalidate index cache for this resource type
-      invalidateCache(data.type);
+  invalidateCache(resourceTypeId);
       
       res.status(201).json(resource);
     } catch (error) {
@@ -363,6 +378,140 @@ export function createAdminRoutes(dbService: DatabaseService, indexCache?: LruCa
       };
 
       res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  // GET /admin/catalog-export - Aggregate all catalogs with resources
+  // Simple, single call for clients needing full metadata dump.
+  // Simplified response shape (fields trimmed):
+  // {
+  //   generated_at: ISO8601,
+  //   catalogs: [{ name, display_name, description, source_type, source_path?, source_url?, created_at, updated_at, resources: { chatmodes: RS[], instructions: RS[], prompts: RS[], tasks: RS[], mcp: RS[] } }],
+  //   counts: { catalogs, resources }
+  // }
+  // RS (ResourceSummary): { filename, title?, description?, category?, tags?, content_type, resource_type, content_url?, metadata?, created_at, updated_at, content?, truncated?, size? }
+  router.get('/catalog-export', async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      interface ResourceExportSummary {
+        filename: string;
+        title?: string;
+        description?: string;
+        category?: string;
+        tags?: string;
+        content_type: string;
+        resource_type: string;
+        content_url?: string;
+        metadata?: Record<string, unknown>;
+        created_at: Date;
+        updated_at: Date;
+        content?: string;
+        truncated?: boolean;
+        size?: number;
+      }
+      interface CatalogExport {
+        name: string;
+        display_name: string | null;
+        description: string | null;
+        source_type: string;
+        source_path?: string;
+        source_url?: string;
+        created_at: Date;
+        updated_at: Date;
+        resources: Record<'chatmodes'|'instructions'|'prompts'|'tasks'|'mcp', ResourceExportSummary[]>;
+      }
+      type CatalogMap = Record<number, CatalogExport>;
+      // Fetch all catalogs
+      const catalogs = await db
+        .selectFrom('catalogs')
+        .selectAll()
+  .where('enabled', '=', 1)
+        .execute();
+
+      if (catalogs.length === 0) {
+        return res.json({ generated_at: new Date().toISOString(), catalogs: [], counts: { catalogs: 0, resources: 0 } });
+      }
+
+      // Fetch all resources for these catalogs in one query
+      const catalogIds = catalogs.map(c => c.id);
+      const resources = await db
+        .selectFrom('resources')
+        .selectAll()
+  .where('catalog_id', 'in', catalogIds)
+  .where('enabled', '=', 1)
+        .execute();
+
+      // Size guard: limit to 10,000 resources to protect server memory
+      if (resources.length > 10_000) {
+        return res.status(413).json({ error: 'export_too_large', max: 10000 });
+      }
+
+      // Group resources by catalog and type
+  const byCatalog: CatalogMap = {};
+      for (const cat of catalogs) {
+        byCatalog[cat.id] = {
+          // id intentionally omitted for lightweight export
+          name: cat.name,
+          display_name: cat.display_name,
+          description: cat.description,
+          source_type: cat.source_type,
+          source_path: cat.source_path ?? undefined,
+          source_url: cat.source_url ?? undefined,
+          // enabled always filtered to 1 so omitted
+          created_at: cat.created_at,
+          updated_at: cat.updated_at,
+          resources: {
+            chatmodes: [],
+            instructions: [],
+            prompts: [],
+            tasks: [],
+            mcp: []
+          }
+        };
+      }
+
+      const INLINE_CONTENT_LIMIT = 50 * 1024; // 50KB to avoid huge payloads
+
+      for (const r of resources) {
+        const cat = byCatalog[r.catalog_id];
+        if (!cat) { continue; }
+        // Parse metadata JSON if present
+        let parsedMeta: Record<string, unknown> | null = null;
+        if (r.metadata) {
+          try { parsedMeta = JSON.parse(r.metadata); } catch { parsedMeta = null; }
+        }
+        const summary = {
+          // id, enabled, and type omitted for simplified payload (type implicit by grouping key)
+          filename: r.filename,
+          title: r.title ?? undefined,
+          description: r.description ?? undefined,
+          category: r.category ?? undefined,
+          tags: r.tags ?? undefined,
+          content_type: r.content_type,
+          resource_type: r.resource_type,
+          content_url: r.content_url ?? undefined,
+          metadata: parsedMeta ?? undefined,
+          created_at: r.created_at,
+          updated_at: r.updated_at,
+          content: (r.resource_type === 'content' && typeof r.content === 'string' && r.content.length <= INLINE_CONTENT_LIMIT) ? r.content : undefined,
+          truncated: (r.resource_type === 'content' && typeof r.content === 'string' && r.content.length > INLINE_CONTENT_LIMIT) ? true : undefined,
+          size: r.resource_type === 'content' ? (typeof r.content === 'string' ? r.content.length : undefined) : undefined
+        };
+    // Push into appropriate array (narrow key without assertion)
+    const key: keyof CatalogExport['resources'] = r.type;
+    cat.resources[key].push(summary);
+      }
+
+  const exportPayload: CatalogExport[] = Object.values(byCatalog);
+      const totalResources = resources.length;
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.json({
+        generated_at: new Date().toISOString(),
+        catalogs: exportPayload,
+        counts: { catalogs: catalogs.length, resources: totalResources }
+      });
     } catch (error) {
       next(error);
     }

--- a/server/src/test/catalogExport.api.test.ts
+++ b/server/src/test/catalogExport.api.test.ts
@@ -1,0 +1,81 @@
+import assert from 'assert';
+import request from 'supertest';
+import { Application } from 'express';
+import { createApp } from '../http/app';
+import { createDatabaseService, DatabaseService } from '../database/service';
+import { MigrationRunner } from '../database/migrationRunner';
+
+// Tests the new /admin/catalog-export aggregated endpoint
+
+describe('Catalog Export API', () => {
+  let app: Application;
+  let dbService: DatabaseService;
+
+  before(function() {
+    try { require('better-sqlite3'); } catch { this.skip(); }
+  });
+
+  beforeEach(async () => {
+    dbService = createDatabaseService({ filename: ':memory:' });
+    await dbService.initialize();
+    const migrationRunner = new MigrationRunner(dbService);
+    await migrationRunner.runMigrations();
+    app = createApp({ config: { port: 0, mode: 'database', databasePath: ':memory:', catalogRoot: '.' }, dbService });
+  });
+
+  afterEach(async () => { await dbService.close(); });
+
+  async function createCatalog(name: string){
+    const res = await request(app).post('/admin/catalogs').send({ name, sourceType: 'local' });
+    assert.strictEqual(res.status, 201);
+    return res.body.id as number;
+  }
+  async function createResource(catalogId: number, type: string, filename: string, content: string){
+    const res = await request(app).post('/admin/resources').send({ catalogId, type, filename, content, resourceType: 'content' });
+    assert.strictEqual(res.status, 201);
+  }
+
+  it('returns empty structure when no catalogs', async () => {
+    const res = await request(app).get('/admin/catalog-export');
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(res.body.catalogs, []);
+    assert.strictEqual(res.body.counts.catalogs, 0);
+  });
+
+  it('returns catalogs with grouped resources', async () => {
+    const catalogId = await createCatalog('grouped');
+    await createResource(catalogId, 'instructions', 'one.instructions.md', '# One');
+    await createResource(catalogId, 'prompts', 'p1.prompt.md', 'Prompt 1');
+    const res = await request(app).get('/admin/catalog-export');
+    assert.strictEqual(res.status, 200);
+    assert.ok(Array.isArray(res.body.catalogs));
+    assert.strictEqual(res.body.counts.catalogs, 1);
+    assert.strictEqual(res.body.counts.resources, 2);
+    const cat = res.body.catalogs[0];
+  type RS = { filename: string };
+  const instr: RS[] = cat.resources.instructions;
+  const prompts: RS[] = cat.resources.prompts;
+  assert.ok(instr.some(r => r.filename === 'one.instructions.md'));
+  assert.ok(prompts.some(r => r.filename === 'p1.prompt.md'));
+  });
+
+  it('inlines small content and flags truncation for large content', async () => {
+    const catalogId = await createCatalog('sizes');
+    await createResource(catalogId, 'instructions', 'small.instructions.md', 'small content');
+    // Create a large string > 50KB
+    const large = 'x'.repeat(60 * 1024);
+    await createResource(catalogId, 'instructions', 'large.instructions.md', large);
+    const res = await request(app).get('/admin/catalog-export');
+    assert.strictEqual(res.status, 200);
+    const cat = res.body.catalogs[0];
+  interface ExtendedRS { filename: string; content?: string; truncated?: boolean; size?: number }
+  const small = (cat.resources.instructions as ExtendedRS[]).find(r => r.filename === 'small.instructions.md');
+  const largeRes = (cat.resources.instructions as ExtendedRS[]).find(r => r.filename === 'large.instructions.md');
+  assert.ok(small, 'expected small resource present');
+  assert.ok(largeRes, 'expected large resource present');
+  assert.ok(small && small.content === 'small content');
+  assert.ok(largeRes && !largeRes.content); // not inlined
+  assert.strictEqual(largeRes?.truncated, true);
+  assert.ok((largeRes?.size ?? 0) > 50 * 1024);
+  });
+});

--- a/server/web-admin/test/setupTests.ts
+++ b/server/web-admin/test/setupTests.ts
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { mockIntersectionObserver } from '../tests/utils/intersectionObserverMock';
+
+afterEach(() => cleanup());
+
+// Suppress Next.js link / intersection observer related act() warnings
+mockIntersectionObserver();
+
+// Lightweight Monaco mock (avoid heavy editor in tests)
+jest.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: () => null
+}));


### PR DESCRIPTION
Adds GET /admin/catalog-export endpoint providing a single, structured export of all enabled catalogs and their enabled resources (instructions, chatmodes, prompts, tasks, MCP) in database/hybrid modes. Designed for synchronization, indexing, environment diffing, and offline snapshot tooling.

Key features:

Single round-trip bulk export (replaces multi-category pulls for admin tooling) Lean, grouping-based schema (resource type implied by array key) Large content safety: inline up to 50KB, truncate with metadata flag + size Hard guard against excessive payloads (>10k resources → 413) Returns only enabled catalogs/resources; no administrative internals Deterministic, cache-control no-store to encourage fresh reads Extensible structure (room for future hashes, pagination, field projection) Documentation:

Section 16 added/updated in remote-catalog-api guide describing contract, constraints, and planned non-breaking enhancements.